### PR TITLE
Fix minor bug in OUP gradients

### DIFF
--- a/fpcross/equation_demo/equation_oup.py
+++ b/fpcross/equation_demo/equation_oup.py
@@ -19,7 +19,9 @@ class EquationOUP(Equation):
         return -X @ self.coef_rhs.T
 
     def f1(self, X, t):
-        return -np.ones(X.shape) @ self.coef_rhs.T
+        shape = X.shape[:-1] + (1, )  # Tiling directions for a row.
+        grads = np.tile(-np.diag(self.coef_rhs), shape)
+        return grads
 
     def init(self):
         self.with_rs = True


### PR DESCRIPTION
It seems that there is a small bug. We need a diagonal of `A` for "diagonal" gradients `d f_i / d x_i` instead of sum of a row (see equations 28 and 29).